### PR TITLE
Fix inconsistent `==`/`===` usage

### DIFF
--- a/chai-shallow-deep-equal.js
+++ b/chai-shallow-deep-equal.js
@@ -34,7 +34,7 @@
 
         // dates
         if (expect.constructor === Date) {
-            if (actual.constructor == Date) {
+            if (actual.constructor === Date) {
                 if (expect.getTime() != actual.getTime()) {
                     throw(
                         'Expected "' + actual.toISOString() + '" to equal ' +


### PR DESCRIPTION
Whooops :-)
